### PR TITLE
fix error getting 'response' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "tape": ""
   },
   "dependencies": {
-    "response": "git://github.com/mikeal/response.git#v0.18.1",
+    "response": "git+https://github.com/mikeal/response.git#v0.18.1",
     "semver": "^5.3.0"
   }
 }


### PR DESCRIPTION
I resolve the dependency resolution in CI from gitlab
Error while executing:
after commit
npm ERR! /usr/bin/git ls-remote -h -t git://github.com/mikeal/response.git
npm ERR! 
npm ERR! fatal: unable to connect to github.com:

error releated to 
https://github.com/mikeal/response/issues/11
https://github.com/rook2pawn/node-ddos/pull/23#issuecomment-351911993

![seleccion_002](https://user-images.githubusercontent.com/7350917/40693677-58fd40c0-637e-11e8-98e2-1bf089febac3.png)
